### PR TITLE
add view for fixing inconsistent catalog state.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,13 @@ same behavior as it used to be with AT, which does fix the error.
 - Plone 4 fix: https://github.com/plone/plone.dexterity/pull/60
 - Plone 5 fix: https://github.com/plone/plone.dexterity/pull/61
 
+**Fix inconsistent state:**
+
+Without this patch, copy / paste could lead to incosinstent state.
+When you've installed ``ftw.copymovepatches`` on an existing installation
+you should visit the view ``copymovepatches-catalog-fixes`` on the site root
+and run the fixes when proposed.
+
 
 Compatibility
 -------------

--- a/ftw/copymovepatches/browser/catalog_fixes.py
+++ b/ftw/copymovepatches/browser/catalog_fixes.py
@@ -1,0 +1,73 @@
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from Products.statusmessages.interfaces import IStatusMessage
+from Products.ZCatalog.ProgressHandler import ZLogHandler
+
+
+class CatalogFixes(BrowserView):
+
+    index = ViewPageTemplateFile('templates/catalog_fixes.pt')
+
+    def __call__(self):
+        return self.index()
+
+    def rebuild_uid_index(self):
+        """Rebuild uid index.
+        """
+        portal_catalog = getToolByName(self.context, 'portal_catalog')
+        portal_catalog._catalog.clearIndex('UID')
+        portal_catalog._catalog.reindexIndex('UID', self.request,
+                                             pghandler=ZLogHandler())
+        IStatusMessage(self.request).addStatusMessage(
+            'Rebuilt UID index.', type='info')
+        return self.redirect_to_view()
+
+    def uid_index_errors(self):
+        if not hasattr(self, '_uid_index_errors'):
+            portal_catalog = getToolByName(self.context, 'portal_catalog')
+            uid_index = portal_catalog._catalog.indexes['UID']
+            self._uid_index_errors = abs(
+                len(uid_index._index) - len(uid_index._unindex))
+
+        return self._uid_index_errors
+
+    def rebuild_brain_metadata(self):
+        """Rebuild brain metadata.
+        """
+        portal_catalog = getToolByName(self.context, 'portal_catalog')
+        for rid in self.get_rids_with_invalid_uid_in_metadata():
+            path = portal_catalog.getpath(rid)
+            obj = self.context.unrestrictedTraverse(path)
+            index = portal_catalog._catalog.uids.get(path, None)
+            portal_catalog._catalog.updateMetadata(obj, path, index)
+
+        IStatusMessage(self.request).addStatusMessage(
+            'Rebuild brain metadata', type='info')
+        return self.redirect_to_view()
+
+    def get_rids_with_invalid_uid_in_metadata(self):
+        if self.uid_index_errors() > 0:
+            # Depends on a valid uid index.
+            return
+
+        portal_catalog = getToolByName(self.context, 'portal_catalog')
+        uid_index = portal_catalog._catalog.indexes['UID']
+
+        for rid in portal_catalog._catalog.paths.keys():
+            uid_from_index = uid_index._unindex.get(rid, None)
+            uid_from_metadata = portal_catalog.getMetadataForRID(rid)['UID']
+            if uid_from_index != uid_from_metadata:
+                yield rid
+
+    def brain_metadata_uid_errors(self):
+        if self.uid_index_errors() > 0:
+            # Depends on a valid uid index.
+            return
+
+        return len(tuple(self.get_rids_with_invalid_uid_in_metadata()))
+
+    def redirect_to_view(self):
+        response = self.request.RESPONSE
+        target = '/'.join((self.context.portal_url(), self.__name__))
+        return response.redirect(target)

--- a/ftw/copymovepatches/browser/configure.zcml
+++ b/ftw/copymovepatches/browser/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="ftw.copymovepatches">
+
+    <browser:page
+        for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot"
+        name="copymovepatches-catalog-fixes"
+        class=".catalog_fixes.CatalogFixes"
+        permission="cmf.ManagePortal"
+        allowed_attributes="rebuild_uid_index rebuild_brain_metadata"
+        />
+
+</configure>

--- a/ftw/copymovepatches/browser/templates/catalog_fixes.pt
+++ b/ftw/copymovepatches/browser/templates/catalog_fixes.pt
@@ -1,0 +1,56 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xml:lang="en"
+      lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="here/prefs_main_template/macros/master"
+      i18n:domain="ftw.upgrade">
+
+    <div metal:fill-slot="prefs_configlet_main"
+         tal:define="uid_index_errors view/uid_index_errors;
+                     has_index_errors python:uid_index_errors>0;
+                     brain_metadata_uid_errors view/brain_metadata_uid_errors;
+                     has_brain_metadata_uid_errors python:brain_metadata_uid_errors>0">
+        <h1>Catalog Problems</h1>
+
+        <p class="uid-index-state-check">
+            <b>UID index state</b>
+            <tal:ERRORS condition="has_index_errors">
+                <b><i>BROKEN:</i></b><br />
+                There are <tal:num replace="uid_index_errors" />
+                errors in the UID index
+                (length difference between forward and backward index BTree).
+                The index should be rebuilt from scratch. <br />
+                &raquo;
+                <a tal:attributes="href string:${portal_url}/copymovepatches-catalog-fixes/rebuild_uid_index">Rebuild UID index</a>
+            </tal:ERRORS>
+            <tal:NOERRORS condition="not:has_index_errors">
+                <b><i>OK:</i></b>
+            </tal:NOERRORS>
+        </p>
+
+        <p class="brain-metadata-check">
+            <b>UIDs in brain metadata:</b>
+            <tal:UID_INDEX_ERRORS condition="has_index_errors">
+                <b><i>UNKOWN:</i></b><br />
+                The brain metadata check depends on the UID index state,
+                which is currently broken.
+            </tal:UID_INDEX_ERRORS>
+            <tal:NO_UID_INDEX_ERRORS condition="not:has_index_errors">
+                <tal:ERRORS condition="brain_metadata_uid_errors">
+                    <b><i>BROKEN:</i></b><br />
+                    There are <tal:num replace="brain_metadata_uid_errors" />
+                    brains with a wrong UID in the metadata.
+                    The UID value in the brain metadata should be recalculated.
+                    <br />
+                    &raquo;
+                    <a tal:attributes="href string:${portal_url}/copymovepatches-catalog-fixes/rebuild_brain_metadata">Rebuild brain metadata</a>
+                </tal:ERRORS>
+                <tal:NOERRORS condition="not:brain_metadata_uid_errors">
+                    <b><i>OK</i></b>
+                </tal:NOERRORS>
+            </tal:NO_UID_INDEX_ERRORS>
+        </p>
+    </div>
+</html>

--- a/ftw/copymovepatches/configure.zcml
+++ b/ftw/copymovepatches/configure.zcml
@@ -4,6 +4,8 @@
     xmlns:monkey="http://namespaces.plone.org/monkey"
     i18n_domain="ftw.copymovepatches">
 
+    <include package=".browser" />
+
     <monkey:patch
         description="Backport dexterity copy flags"
         class="plone.dexterity.content.PasteBehaviourMixin"

--- a/ftw/copymovepatches/tests/test_catalog_fixes_view.py
+++ b/ftw/copymovepatches/tests/test_catalog_fixes_view.py
@@ -1,0 +1,73 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.copymovepatches.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from plone.uuid.interfaces import IUUID
+from plone.uuid.interfaces import IUUIDGenerator
+from Products.Archetypes import config
+from Products.CMFCore.utils import getToolByName
+from zope.component import getUtility
+import transaction
+
+
+class TestCatalogFixesView(FunctionalTestCase):
+
+    @browsing
+    def test_rebuild_broken_uid_index(self, browser):
+        self.grant('Manager')
+        page = create(Builder('page'))
+        self.break_object(page)
+
+        browser.login().open(view='copymovepatches-catalog-fixes')
+        self.assertEquals(
+            u'UID index state BROKEN:\n'
+            u'There are 1 errors in the UID index'
+            u' (length difference between forward and backward index BTree).'
+            u' The index should be rebuilt from scratch.\n'
+            u'\xbb Rebuild UID index',
+            browser.css('.uid-index-state-check').first.text)
+        browser.click_on('Rebuild UID index')
+        self.assertEquals(
+            'UID index state OK:',
+            browser.css('.uid-index-state-check').first.text)
+
+    @browsing
+    def test_rebuild_broken_brain_metadata(self, browser):
+        self.grant('Manager')
+        page = create(Builder('page'))
+        self.break_object(page)
+
+        browser.login().open(view='copymovepatches-catalog-fixes')
+        self.assertEquals(
+            u'UIDs in brain metadata: UNKOWN:\n'
+            u'The brain metadata check depends on the UID index state,'
+            u' which is currently broken.',
+            browser.css('.brain-metadata-check').first.text)
+        browser.click_on('Rebuild UID index')
+
+        self.assertEquals(
+            u'UIDs in brain metadata: BROKEN:\n'
+            u'There are 1 brains with a wrong UID in the metadata.'
+            u' The UID value in the brain metadata should be recalculated.\n'
+            u'\xbb Rebuild brain metadata',
+            browser.css('.brain-metadata-check').first.text)
+        browser.click_on('Rebuild brain metadata')
+
+        self.assertEquals(
+            'UIDs in brain metadata: OK',
+            browser.css('.brain-metadata-check').first.text)
+
+    def break_object(self, obj):
+        # Simulate that the object was copied without properly updating
+        # the new UID, leaving the catalog in an inconsistent state.
+
+        # Break UID index
+        portal_catalog = getToolByName(self.portal, 'portal_catalog')
+        del portal_catalog._catalog.indexes['UID']._index[IUUID(obj)]
+
+        # Change UID so that brain metadata is incorrect.
+        # This used to happen on copy/paste without the patch provided
+        # by this package.
+        setattr(obj, config.UUID_ATTR, getUtility(IUUIDGenerator)())
+
+        transaction.commit()


### PR DESCRIPTION
Without this patch, copy / paste could lead to incosinstent state.
When you've installed ``ftw.copymovepatches`` on an existing installation you should visit the view ``copymovepatches-catalog-fixes`` on the site root and run the fixes when proposed.