### PR TITLE
Implement `delete`.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.0a2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Implement `delete`.
+  [mathias.leimgruber]
 
 
 1.0.0a1 (2016-09-02)

--- a/ftw/copymovepatches/cmfcatalogaware.py
+++ b/ftw/copymovepatches/cmfcatalogaware.py
@@ -83,12 +83,16 @@ def handleContentishEvent(ob, event):
             delattr(ob, '__rid')
 
     elif IObjectWillBeMovedEvent.providedBy(event):
-        if event.oldParent is not None:
+        # Move/Rename
+        if event.oldParent is not None and event.newParent is not None:
             catalog = api.portal.get_tool('portal_catalog')
             ob_path = '/'.join(ob.getPhysicalPath())
             rid = catalog._catalog.uids[ob_path]
 
             setattr(ob, '__rid', rid)
+        else:
+            # Delete
+            ob.unindexObject()
 
     elif IObjectCopiedEvent.providedBy(event):
         if hasattr(aq_base(ob), 'workflow_history'):

--- a/ftw/copymovepatches/tests/test_move_rename.py
+++ b/ftw/copymovepatches/tests/test_move_rename.py
@@ -85,3 +85,10 @@ class TestRenameMove(FunctionalTestCase):
 
         new_path = '/'.join(self.target.objectValues()[0].getPhysicalPath())
         self.assertNotEquals(rid, self.catalog._catalog.uids[new_path])
+
+    def test_crosscheck_delete_still_works(self):
+        old_path = '/'.join(self.source.getPhysicalPath())
+        self.portal.manage_delObjects([self.source.getId()])
+
+        self.assertFalse(len(self.catalog(path=old_path)),
+                         'No longer expecting this item in the catalog')


### PR DESCRIPTION
This fixes a problem, when the object gets removed and not moved/renamed.

Could have seen this coming :-(