### PR TITLE
Make add-on more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.0.0a3 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Make add-on more robust by handling a special case which may happen when
+  "collective.indexing" is installed and an object is created with "plone.api"
+  in a subscriber listening on "IObjectAddedEvent".
+  [mbaechtold, mathias.leimgruber]
 
 
 1.0.0a2 (2016-09-05)


### PR DESCRIPTION
The increased robustness is achieved by handling a special case which may happen when "collective.indexing" is installed and an object is created with "plone.api" in a subscriber listening on "IObjectAddedEvent",  e.g. in  https://github.com/4teamwork/ftw.events/blob/f1a77440866c6d963961497f68781098c1b4bc8f/ftw/events/configure.zcml#L22