### PR TITLE
Fix edge case with collective.indexing and other 3rd party packages and rename a nested structure.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,11 @@ Changelog
 =========
 
 
-1.0.0a5 (unreleased)
---------------------
+1.0.0 (unreleased)
+------------------
 
-- Nothing changed yet.
+- Fix edge case with collective.indexing and other 3rd party packages and rename a nested structure.
+  [mathias.leimgruber]
 
 
 1.0.0a4 (2016-09-07)

--- a/ftw/copymovepatches/testing.py
+++ b/ftw/copymovepatches/testing.py
@@ -5,6 +5,7 @@ from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
+from plone.testing import z2
 from zope.configuration import xmlconfig
 import ftw.copymovepatches.tests.builders
 
@@ -21,6 +22,8 @@ class FtwLayer(PloneSandboxLayer):
             '  <include package="ftw.copymovepatches.tests" file="profiles.zcml" />'
             '</configure>',
             context=configurationContext)
+
+        z2.installProduct(app, 'collective.indexing')
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'ftw.copymovepatches.tests:default')

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 from setuptools import setup, find_packages
 
-version = '1.0.0a5.dev0'
+version = '1.0.0.dev0'
 maintainer = '4teamwork'
 
 tests_require = [
+    'collective.indexing',
     'ftw.builder',
-    'ftw.testing',
     'ftw.testbrowser',
+    'ftw.testing',
     'plone.app.testing',
     'plone.testing',
 ]


### PR DESCRIPTION

The queue needs to be processed, since the `renameObjectsByPaths`
script allows the user to rename the object and also sets a new
title if he wants.
In some circumstances this leads to a inconsistent catalog state.
Mainly if other event handler also triggers a `process` queue by
asking the catalog for something.
The result was for example a "reindex" of a already deleteobject.


Also prepeare for Release 1.0.0 - Guess this one is ready!!