### PR TITLE
Also reindex Date (which defaults to modified) when moving an object.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Also reindex Date (which defaults to modified) when moving an object. [njohner]
 - Fixed error (`issue 13 <https://github.com/4teamwork/ftw.copymovepatches/issues/13>`_)  when renaming Plone Site.  [maurits]
 
 

--- a/ftw/copymovepatches/cmfcatalogaware.py
+++ b/ftw/copymovepatches/cmfcatalogaware.py
@@ -83,6 +83,7 @@ def handleContentishEvent(ob, event):
                     'path',
                     'allowedRolesAndUsers',
                     'modified',
+                    'Date',
                     'id',
                     'getId'])
 

--- a/ftw/copymovepatches/tests/test_move_updates_date_date.py
+++ b/ftw/copymovepatches/tests/test_move_updates_date_date.py
@@ -1,0 +1,11 @@
+from ftw.copymovepatches.tests import test_move_updates_modified_date
+from DateTime import DateTime
+
+
+class TestMoveUpdatesDateDate(test_move_updates_modified_date.TestMoveUpdatesModifiedDate):
+
+    date_name = 'Date'
+
+    def assert_date_metadata(self, expected_date, metadata_date):
+        zone = DateTime().timezone()
+        self.assertEqual(expected_date, DateTime(metadata_date).toZone(zone))

--- a/ftw/copymovepatches/tests/test_move_updates_modified_date.py
+++ b/ftw/copymovepatches/tests/test_move_updates_modified_date.py
@@ -9,50 +9,64 @@ from plone import api
 
 class TestMoveUpdatesModifiedDate(FunctionalTestCase):
 
-    def test_moving_AT_object_updates_modified_date(self):
+    date_name = 'modified'
+
+    def get_date_on_object(self, obj):
+        return getattr(obj, self.date_name)()
+
+    def test_moving_AT_object_updates_date(self):
         self.grant('Manager')
         old_parent = create(Builder('folder').titled(u'Old Parent'))
         new_parent = create(Builder('folder').titled(u'New Parent'))
 
         with freeze(datetime(2000, 1, 1)) as clock:
             folder = create(Builder('folder').within(old_parent))
-            self.assert_modified_date(datetime(2000, 1, 1), folder)
+            self.assert_date(datetime(2000, 1, 1), folder)
 
             clock.forward(days=4)
             new_parent.manage_pasteObjects(old_parent.manage_cutObjects(
                 [folder.getId()]))
             folder = new_parent.get(folder.getId())
-            self.assert_modified_date(datetime(2000, 1, 5), folder)
+            self.assert_date(datetime(2000, 1, 5), folder)
 
-    def test_moving_DX_object_updates_modified_date(self):
+    def test_moving_DX_object_updates_date(self):
         self.grant('Manager')
         old_parent = create(Builder('dx container').titled(u'Old Parent'))
         new_parent = create(Builder('dx container').titled(u'New Parent'))
 
         with freeze(datetime(2000, 1, 1)) as clock:
             folder = create(Builder('dx container').within(old_parent))
-            self.assert_modified_date(datetime(2000, 1, 1), folder)
+            self.assert_date(datetime(2000, 1, 1), folder)
 
             clock.forward(days=4)
             new_parent.manage_pasteObjects(old_parent.manage_cutObjects(
                 [folder.getId()]))
             folder = new_parent.get(folder.getId())
-            self.assert_modified_date(datetime(2000, 1, 5), folder)
+            self.assert_date(datetime(2000, 1, 5), folder)
 
-    def assert_modified_date(self, expected_date, obj):
+    def assert_date(self, expected_date, obj):
         expected_date = DateTime(expected_date)
-        self.assertEquals(expected_date,
-                          DateTime(obj.modified()),
-                          'Wrong modification date on object.')
-        self.assert_modified_date_in_catalog(expected_date, obj)
+        self.assertEquals(
+            expected_date,
+            DateTime(self.get_date_on_object(obj)).toZone(DateTime().timezone()),
+            'Wrong {} date on object.'.format(self.date_name))
+        self.assert_date_in_catalog(expected_date, obj)
 
-    def assert_modified_date_in_catalog(self, expected_date, obj):
+    def assert_date_in_catalog(self, expected_date, obj):
         catalog = api.portal.get_tool('portal_catalog')
         catalog_uid = '/'.join(obj.getPhysicalPath())
-        metadata = catalog.getMetadataForUID(catalog_uid)
-        self.assertEquals(expected_date, metadata['modified'],
-                          'Wrong modification date in catalog metadata.')
 
+        metadata = catalog.getMetadataForUID(catalog_uid)
+        self.assert_date_metadata(expected_date, metadata[self.date_name])
+
+        indexdata = catalog.getIndexDataForUID(catalog_uid)
+        self.assert_date_indexdata(expected_date, indexdata[self.date_name])
+
+    def assert_date_metadata(self, expected_date, metadata_date):
+        self.assertEquals(expected_date, metadata_date,
+                          'Wrong {} date in catalog metadata.'.format(self.date_name))
+
+    def assert_date_indexdata(self, expected_date, indexdata_date):
         # from date index
         t_tup = expected_date.toZone('UTC').parts()
         yr = t_tup[0]
@@ -62,6 +76,5 @@ class TestMoveUpdatesModifiedDate(FunctionalTestCase):
         mn = t_tup[4]
         expected_val = ( ( ( ( yr * 12 + mo ) * 31 + dy ) * 24 + hr ) * 60 + mn )
 
-        indexdata = catalog.getIndexDataForUID(catalog_uid)
-        self.assertEquals(expected_val, indexdata['modified'],
-                          'Wrong modification date in catalog index.')
+        self.assertEquals(expected_val, indexdata_date,
+                          'Wrong {} date in catalog index.'.format(self.date_name))


### PR DESCRIPTION
The `Date` index should also be reindexed when moving an object, as it defaults to modified and is hence updated when an object is moved. This is part of https://github.com/4teamwork/opengever.core/issues/5720