### PR TITLE
Fix tests after ftw.testing release.

### DIFF
--- a/ftw/copymovepatches/tests/__init__.py
+++ b/ftw/copymovepatches/tests/__init__.py
@@ -1,7 +1,7 @@
 from ftw.copymovepatches.testing import FTW_FUNCTIONAL
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from unittest import TestCase
 import transaction
 
 


### PR DESCRIPTION
Use unittest instead of unittest2 (dependency was not declared).